### PR TITLE
feat(architecture): Remove schema directory and enhance Pydantic model documentation

### DIFF
--- a/.docs/uml/components.puml
+++ b/.docs/uml/components.puml
@@ -42,7 +42,7 @@ package "Artifacts" {
   [BenchmarkReport.json]
   [BenchmarkComparison.md]
   [metrics.yaml]
-  [Schema (JSON)]
+  [Pydantic Models]
 }
 
 [datasets sync] --> [IngestionManifest (JSON)] : write spec
@@ -76,12 +76,12 @@ package "Artifacts" {
 [Evaluation CLI] --> [EvaluationReport.json]
 [Evaluation CLI] --> [ExperimentManifest.jsonl]
 [Evaluation CLI] --> [metrics.yaml]
-[Evaluation CLI] --> [Schema (JSON)]
+[Evaluation CLI] --> [Pydantic Models]
 [Evaluation CLI] --> [BenchmarkReport.json]
 [Evaluation CLI] --> [BenchmarkComparison.md]
 
-[Schema (JSON)] --> [FastAPI Layer] : shared models
-[Schema (JSON)] --> [Evaluation CLI] : shared models
+[Pydantic Models] --> [FastAPI Layer] : shared models
+[Pydantic Models] --> [Evaluation CLI] : shared models
 
 @enduml
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@
 │  └─ eval/           # Evaluation CLI + TREC tooling (stubbed)
 ├─ frontend/          # Deno prototype (Next.js migration planned)
 ├─ shared/            # Pydantic models + enums shared across services
-├─ schema/            # JSON Schemas used by pipelines and API
 ├─ scripts/           # Automation (deps update, UML generation)
 └─ .docs/             # Setup guides, API docs, UML, KPIs, meeting notes
 ```
@@ -72,11 +71,17 @@ flowchart TD
 | Blue | Orange | Green | Purple | Red |
 
 ### Data Contracts
-All data types referenced in the diagram above are defined in [`shared/`](shared/) and documented in [`.docs/uml/classes.puml`](.docs/uml/classes.puml):
-- `DatasetSpec`, `ChunkingSpec` — dataset metadata and chunking configuration.
-- `IndexTarget` — registered index endpoints (BM25, vector, hybrid planned).
-- `MetadataResponse` — API payload bundling dataset, chunking, and index registry details.
-- `RetrievalRequest`, `RetrievalResponse`, `RetrievedSegment`, `QueryResult`, `RetrievalDiagnostics` — retrieval contracts exposed by the API.
+All data types referenced in the diagram above are defined as **Pydantic models** in [`shared/`](shared/) and documented in [`.docs/uml/classes.puml`](.docs/uml/classes.puml). These models provide:
+- **Runtime validation** for all API requests and responses
+- **Automatic OpenAPI schema generation** for FastAPI documentation
+- **Type safety** across all Python services
+- **Serialization/deserialization** with built-in JSON support
+
+Key model categories:
+- `DatasetSpec`, `ChunkingSpec` — dataset metadata and chunking configuration
+- `IndexTarget` — registered index endpoints (BM25, vector, hybrid planned)
+- `MetadataResponse` — API payload bundling dataset, chunking, and index registry details
+- `RetrievalRequest`, `RetrievalResponse`, `RetrievedSegment`, `QueryResult`, `RetrievalDiagnostics` — retrieval contracts exposed by the API
 
 ### 1. Dataset (Development Subset)
 - Curated slice of the corpus for fast iteration and cost control.


### PR DESCRIPTION
Consolidate data type definitions in shared/ directory and improve
documentation of Pydantic models. Highlight runtime validation,
OpenAPI schema generation, type safety, and serialization benefits.
Update component diagrams to reflect model terminology changes.